### PR TITLE
Write response to a file and refetch the response on acf-options update

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -44,9 +44,11 @@ class AgreableVenuesPlugin
   }
 
   public function clearCachedResponse() {
-    $screen = get_current_screen();
-    if (strpos($screen->id, "acf-options") == true) {
-      unlink($this::FILE_LOCATION);
+    if (function_exists('get_current_screen')) {
+      $screen = get_current_screen();
+      if ($screen->id && (strpos($screen->id, "acf-options") == true)) {
+        unlink($this::FILE_LOCATION);
+      }
     }
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -34,11 +34,21 @@ use AgreableVenuesPlugin\Helper;
 
 class AgreableVenuesPlugin
 {
+  const FILE_LOCATION = "/tmp/kitchin-brand-response.json";
+
 	public function __construct()
 	{
     $ns = Helper::get('agreable_namespace');
     add_filter("acf/load_field/key={$ns}_plugin_brand", array($this, 'loadBrands'), 11, 3);
+    add_action('acf/save_post', array($this, 'clearCachedResponse'), 20);
   }
+
+  public function clearCachedResponse() {
+    $screen = get_current_screen();
+    if (strpos($screen->id, "acf-options") == true) {
+      unlink($this::FILE_LOCATION);
+    }
+}
 
   public function loadBrands($field) {
     $baseUri = getenv('KITCHIN_API');
@@ -49,12 +59,17 @@ class AgreableVenuesPlugin
     ]);
 
     try {
-      $response = $client->get(
-        'api/v1/brand'
-      );
-      $body = (string) $response->getBody();
+      if (file_exists($this::FILE_LOCATION)) {
+        $body = file_get_contents($this::FILE_LOCATION);
+      } else {
+        $response = $client->get(
+          'api/v1/brand'
+        );
+        $body = (string) $response->getBody();
+        file_put_contents($this::FILE_LOCATION, $body);
+      }
       $responseObject = json_decode($body, true, JSON_PRETTY_PRINT);
-      
+
       foreach ($responseObject as $key => $brand) {
         $field['choices'][$brand['id']] = $brand['name'];
       }

--- a/plugin.php
+++ b/plugin.php
@@ -46,8 +46,10 @@ class AgreableVenuesPlugin
   public function clearCachedResponse() {
     if (function_exists('get_current_screen')) {
       $screen = get_current_screen();
-      if ($screen->id && (strpos($screen->id, "acf-options") == true)) {
-        unlink($this::FILE_LOCATION);
+      if (isset($screen->id) && (strpos($screen->id, "acf-options") == true)) {
+        if (file_exists($this::FILE_LOACTION)) {
+          unlink($this::FILE_LOCATION);
+        }
       }
     }
 }


### PR DESCRIPTION
Prevent the acf-option load for Kitchin brand firing over the network on every load.

The cache file is updated each time you click update on the acf-options page.